### PR TITLE
upgrade accelerate in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch == 2.0.0
 torchvision == 0.15.1
 evaluate == 0.4.0
 datasets == 2.10.0
-accelerate == 0.19.0
+accelerate == 0.31.0
 fairscale == 0.4.13
 tensorboard == 2.12.1
 sentencepiece == 0.1.97


### PR DESCRIPTION
If you install version 0.19.0 of accelerate listed in the current requirements.txt, you will encounter the following error. 
Therefore, I have updated the accelerate version to the latest one.

ImportError: cannot import name 'is_npu_available' from 'accelerate.utils' (/home/dodo/.conda/envs/llm_py310/lib/python3.10/site-packages/accelerate/utils/__init__.py)